### PR TITLE
Change "Set Limit = 500" to "Set WorldEdit Limit"

### DIFF
--- a/src/main/resources/ftc_settings.xml
+++ b/src/main/resources/ftc_settings.xml
@@ -117,7 +117,7 @@
             <command>purgeall</command>
         </favoriteButton>
         <favoriteButton>
-            <label>Set Limit = 500</label>
+            <label>Set WorldEdit Limit</label>
             <command>setl</command>
         </favoriteButton>
         <favoriteButton>


### PR DESCRIPTION
Due to the inconsistent limits within TotalFreedomMod, we should call it "WorldEdit Limit" instead of an exact number.  For example, older versions of TotalFreedomMod have '500' as it's limit, and now the current version has 2500 as it's limit.
